### PR TITLE
Improve docs and add unit tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # custom
-#keys.yaml
+keys.yaml
 
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-A configuration-as-code approach to openai's api
+## GPT API Wrapper
+
+Small utilities for calling the OpenAI API using YAML profiles.  Profiles define
+the model, prompts and structured output schema so you can keep configuration
+out of the code.
+
+### Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Copy `keys.yaml.example` to `keys.yaml` and add your OpenAI API key:
+
+   ```yaml
+   openai_api: "sk-..."
+   ```
+
+### Usage
+
+- Run the simple example:
+
+  ```bash
+  python example.py
+  ```
+
+- Run the multi agent demo with a schedule file:
+
+  ```bash
+  python multiagent.py --schedule schedules/example-schema.yaml "Your prompt"
+  ```
+
+### Development
+
+Run tests with `pytest` (requires the `pytest-cov` plugin) and optionally lint with `flake8` if available. The command below also checks that code coverage stays above 80%:
+
+```bash
+pytest --cov=gptapi_core --cov-report=term --cov-fail-under=80
+flake8  # optional
+```

--- a/example.py
+++ b/example.py
@@ -28,7 +28,7 @@ def main():
     """
     try:
         # Define the profile name and input file path
-        profile_name = 'cot'  # The YAML profile file name without the extension
+        profile_name = 'reason'  # The YAML profile file name without extension
         input_file_path = './input.txt'  # Path to the input file containing the prompt
 
         # Read the prompt from the input file

--- a/gptapi_core.py
+++ b/gptapi_core.py
@@ -145,3 +145,11 @@ def run_web_search(query: str, *, model: str = "gpt-4.1-mini") -> str:
             references_section += f"[{refnum}]: {title or url} <{url}>\n"
 
     return "\n".join(segments).strip() + references_section
+
+
+def gptapi(profile_name: str, prompt: str, base_dir: str | None = None):
+    """Convenience wrapper to load a profile and call the model."""
+    base_dir = base_dir or os.path.join(os.path.dirname(__file__), "profiles")
+    profile = load_profile(profile_name, base_dir)
+    messages = [{"role": "user", "content": prompt}]
+    return call_structured(profile, messages)

--- a/keys.yaml.example
+++ b/keys.yaml.example
@@ -1,0 +1,1 @@
+openai_api: "sk-your-api-key"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+PyYAML
+pytest
+pytest-cov

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide a tiny YAML stub so gptapi_core imports without PyYAML installed
+yaml_stub = types.SimpleNamespace()
+def _safe_load(data):
+    if hasattr(data, 'read'):
+        data = data.read()
+    d = {}
+    for line in str(data).splitlines():
+        if ':' in line:
+            k, v = line.split(':', 1)
+            val = v.strip()
+            if val.isdigit():
+                val = int(val)
+            d[k.strip()] = val
+    return d
+yaml_stub.safe_load = _safe_load
+sys.modules.setdefault('yaml', yaml_stub)
+
+# Minimal stub for openai.OpenAI used in gptapi_core
+class _DummyOpenAI:
+    def __init__(self, *a, **k):
+        pass
+
+    class chat:
+        class completions:
+            @staticmethod
+            def create(**kwargs):
+                class Resp:
+                    choices = [types.SimpleNamespace(message=types.SimpleNamespace(tool_calls=[types.SimpleNamespace(function=types.SimpleNamespace(arguments='{}'))]))]
+                return Resp()
+
+    class responses:
+        @staticmethod
+        def create(**kwargs):
+            class Resp:
+                output_text = 'result'
+                content = []
+            return Resp()
+
+sys.modules.setdefault('openai', types.SimpleNamespace(OpenAI=_DummyOpenAI))
+
+from gptapi_core import _load_yaml, load_profile, gptapi
+
+def test_load_yaml(tmp_path):
+    p = tmp_path / "sample.yaml"
+    p.write_text("a: 1\n")
+    assert _load_yaml(p) == {"a": 1}
+
+def test_load_profile():
+    base = os.path.join(os.path.dirname(__file__), "..", "profiles")
+    prof = load_profile("reason", base)
+    for key in ("model", "system_prompt", "parameters", "structured_output"):
+        assert key in prof
+
+def test_gptapi_calls(monkeypatch):
+    called = {}
+    def fake_call(profile, messages):
+        called['profile'] = profile
+        called['messages'] = messages
+        return {'ok': True}
+
+    monkeypatch.setattr('gptapi_core.call_structured', fake_call)
+    result = gptapi("reason", "hi", base_dir=os.path.join(os.path.dirname(__file__), "..", "profiles"))
+    assert result == {'ok': True}
+    assert called['messages'][0]['content'] == "hi"


### PR DESCRIPTION
## Summary
- expand README with setup and usage docs
- provide example credentials file and requirements
- add simple flake8 config
- fix example profile name and add `gptapi` helper function
- add unit tests using stubs for missing deps
- document coverage check with pytest-cov

## Testing
- `pytest -q`
- `pytest --cov=gptapi_core --cov-report=term --cov-fail-under=80 -q` *(fails: unrecognized arguments)*
- `flake8 .` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866834338008330a28d82229185e920